### PR TITLE
Bump celery 5 deps to latest

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-click==7.1.2
-prometheus-client==0.10.1
-redis==4.0.0
+click==8.0.3
+prometheus-client==0.12.0
+redis==4.1.1

--- a/requirements/requirements_celery.txt
+++ b/requirements/requirements_celery.txt
@@ -1,3 +1,3 @@
 -r base.txt
 billiard==3.6.4.0
-pytz==2021.1
+pytz==2021.3

--- a/requirements/requirements_celery5.txt
+++ b/requirements/requirements_celery5.txt
@@ -1,4 +1,4 @@
 -r requirements_celery.txt
-celery==5.1.2
-kombu==5.1.0
+celery==5.2.3
+kombu==5.2.3
 vine==5.0.0


### PR DESCRIPTION
~Should fix worker ping error when used with `celery` 5.2.3~
This doesn't fix the issue, but we should still bump to latest

```py
workers-thread:ERROR: Error while pinging workers
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/celery_exporter/monitor.py", line 88, in update_workers_count
    len(self._app.control.ping(timeout=self.celery_ping_timeout_seconds))
  File "/usr/local/lib/python3.6/site-packages/celery/app/control.py", line 530, in ping
    timeout=timeout, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/celery/app/control.py", line 743, in broadcast
    limit, callback, channel=channel,
  File "/usr/local/lib/python3.6/site-packages/kombu/pidbox.py", line 350, in _broadcast
    channel=chan)
  File "/usr/local/lib/python3.6/site-packages/kombu/pidbox.py", line 389, in _collect
    self.connection.drain_events(timeout=timeout)
  File "/usr/local/lib/python3.6/site-packages/kombu/connection.py", line 318, in drain_events
    return self.transport.drain_events(self.connection, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/kombu/transport/virtual/base.py", line 960, in drain_events
    get(self._deliver, timeout=timeout)
  File "/usr/local/lib/python3.6/site-packages/kombu/transport/redis.py", line 420, in get
    ret = self.handle_event(fileno, event)
  File "/usr/local/lib/python3.6/site-packages/kombu/transport/redis.py", line 402, in handle_event
    return self.on_readable(fileno), self
  File "/usr/local/lib/python3.6/site-packages/kombu/transport/redis.py", line 398, in on_readable
    chan.handlers[type]()
  File "/usr/local/lib/python3.6/site-packages/kombu/transport/redis.py", line 779, in _brpop_read
    **options)
  File "/usr/local/lib/python3.6/site-packages/redis/client.py", line 1101, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 757, in read_response
    response = self._parser.read_response()
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 473, in read_response
    self.read_from_socket()
  File "/usr/local/lib/python3.6/site-packages/redis/connection.py", line 432, in read_from_socket
    raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
redis.exceptions.ConnectionError: Connection closed by server.
```