### PR TITLE
python cleanup types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ static_analysis: build_dev ## Run mypy
 lint: build_dev ## Run flake8
 	$(docker_shell) "flake8"
 
+tests: static_analysis lint test ##  Run test and lint and static_analysis
+
 format: build_dev ## Apply black + isort formatting 
 	$(docker_shell) "black ."
 	$(docker_shell) "isort ."

--- a/celery_exporter/__main__.py
+++ b/celery_exporter/__main__.py
@@ -137,9 +137,7 @@ def main(
         try:
             transport_options = json.loads(transport_options)
         except ValueError:
-            logging.error(
-                "Error parsing broker transport options from JSON '{}'".format(transport_options)
-            )
+            logging.error(f"Error parsing broker transport options from JSON '{transport_options}'")
             sys.exit(1)
 
     broker_use_ssl = generate_broker_use_ssl(

--- a/celery_exporter/__main__.py
+++ b/celery_exporter/__main__.py
@@ -4,6 +4,8 @@ import os
 import signal
 import sys
 import time
+from types import FrameType
+from typing import Optional, Union
 
 import click
 
@@ -11,6 +13,14 @@ from .core import CeleryExporter
 from .utils import generate_broker_use_ssl, get_transport_scheme
 
 LOG_FORMAT = "[%(asctime)s] %(name)s:%(levelname)s: %(message)s"
+
+
+def shutdown(signum: Union[int, signal.Signals], frame: Optional[FrameType]):
+    """
+    Shutdown is called if the process receives a TERM/INT signal.
+    """
+    logging.info("Shutting down")
+    sys.exit(0)
 
 
 @click.command(context_settings={"auto_envvar_prefix": "CELERY_EXPORTER"})
@@ -153,13 +163,6 @@ def main(
     )
 
     celery_exporter.start()
-
-    def shutdown(signum, frame):  # pragma: no cover
-        """
-        Shutdown is called if the process receives a TERM/INT signal.
-        """
-        logging.info("Shutting down")
-        sys.exit(0)
 
     signal.signal(signal.SIGINT, shutdown)
     signal.signal(signal.SIGTERM, shutdown)

--- a/celery_exporter/celery_state.py
+++ b/celery_exporter/celery_state.py
@@ -61,11 +61,11 @@ class Task:
             raise TypeError(f"Except type str for kind, found {type(kind)}")
 
         splitted = kind.split("-")
-        state = splitted[1]
+        state_str = splitted[1]
 
         if is_task_event(kind):
             uuid = event.get("uuid", CELERY_MISSING_DATA)
-            state = TaskState.from_event(state)
+            state = TaskState.from_event(state_str)
             local_received = event.get("local_received")
             if local_received is None:
                 raise ValueError("Invalid Event: missing local_received")

--- a/celery_exporter/celery_state.py
+++ b/celery_exporter/celery_state.py
@@ -73,7 +73,6 @@ class Task:
                 raise TypeError(
                     f"Expected type float for local_received, found {type(local_received)}"
                 )
-            local_received = local_received
 
             name = event.get("name", CELERY_MISSING_DATA)
             runtime = event.get("runtime", cls.runtime)

--- a/celery_exporter/celery_state.py
+++ b/celery_exporter/celery_state.py
@@ -10,6 +10,7 @@ CELERY_MISSING_DATA = "undefined"
 CollectOutcome = Tuple[Optional[str], Optional[str], Optional[float], Optional[str]]
 # name, queue, latency
 LatencyOutcome = Tuple[Optional[str], Optional[str], Optional[float]]
+Event = Dict  # Celery event only has type as the required field
 
 
 def is_task_event(kind: str) -> bool:
@@ -53,7 +54,7 @@ class Task:
     state: TaskState = TaskState.UNDEFINED
 
     @classmethod
-    def from_event(cls, event: Dict) -> "Task":
+    def from_event(cls, event: Event) -> "Task":
         kind: Optional[str] = event.get("type")
         if kind is None:
             raise ValueError("Invalid Event: missing type")
@@ -111,7 +112,7 @@ class CeleryState:
         if task.state == TaskState.RECEIVED:
             self.task_count += 1
 
-    def collect(self, event: Dict) -> CollectOutcome:
+    def collect(self, event: Event) -> CollectOutcome:
         kind: Optional[str] = event.get("type")
         if kind is None:
             raise ValueError("Invalid Event: missing type")
@@ -146,7 +147,7 @@ class CeleryState:
             queue = self.queue_by_task.get(name, CELERY_MISSING_DATA)
             return (name, task.state.value, None, queue)
 
-    def latency(self, event: Dict) -> LatencyOutcome:
+    def latency(self, event: Event) -> LatencyOutcome:
         kind: Optional[str] = event.get("type")
         if kind is None:
             raise ValueError("Invalid Event: missing type")

--- a/celery_exporter/core.py
+++ b/celery_exporter/core.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Dict, Optional, Union
 
 import celery
 import prometheus_client
@@ -18,14 +19,14 @@ __all__ = ("CeleryExporter",)
 class CeleryExporter:
     def __init__(
         self,
-        broker_url,
-        listen_address,
+        broker_url: str,
+        listen_address: str,
         max_tasks: int = 10000,
-        namespace="celery",
-        transport_options=None,
-        enable_events=False,
-        queues=None,
-        broker_use_ssl=None,
+        namespace: str = "celery",
+        transport_options: Optional[Dict] = None,
+        enable_events: bool = False,
+        queues: Optional[Any] = None,
+        broker_use_ssl: Optional[Union[bool, Dict]] = None,
     ):
         self._listen_address = listen_address
         self._max_tasks = max_tasks

--- a/celery_exporter/core.py
+++ b/celery_exporter/core.py
@@ -71,5 +71,5 @@ class CeleryExporter:
         thread.
         """
         host, port = self._listen_address.split(":")
-        logging.info("Starting HTTPD on {}:{}".format(host, port))
+        logging.info(f"Starting HTTPD on {host}:{port}")
         prometheus_client.start_http_server(int(port), host)

--- a/celery_exporter/metrics.py
+++ b/celery_exporter/metrics.py
@@ -14,7 +14,7 @@ DEFAULT_BUCKETS = {
 
 
 def get_buckets(key: str) -> List[float]:
-    env_var = "CELERY_EXPORTER_{}_BUCKETS".format(key.upper())
+    env_var = f"CELERY_EXPORTER_{key.upper()}_BUCKETS"
     val = os.environ.get(env_var)
     if val is not None:
         try:

--- a/celery_exporter/monitor.py
+++ b/celery_exporter/monitor.py
@@ -10,7 +10,7 @@ from celery.utils.objects import FallbackContext
 from prometheus_client.core import GaugeMetricFamily
 from prometheus_client.registry import Collector
 
-from .celery_state import CeleryState
+from .celery_state import CeleryState, Event
 from .metrics import LATENCY, TASKS, TASKS_RUNTIME
 from .utils import get_config
 
@@ -36,7 +36,7 @@ class TaskThread(threading.Thread):
     def run(self):  # pragma: no cover
         self._monitor()
 
-    def _process_event(self, event: Dict):
+    def _process_event(self, event: Event):
         (name, queue, latency) = self._state.latency(event)
         if latency is not None:
             LATENCY.labels(namespace=self._namespace, name=name, queue=queue).observe(latency)

--- a/celery_exporter/utils.py
+++ b/celery_exporter/utils.py
@@ -1,12 +1,15 @@
 import ssl
 from itertools import chain
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
+
+from celery import Celery
 
 CELERY_DEFAULT_QUEUE = "celery"
 CELERY_MISSING_DATA = "undefined"
 
 
-def _gen_wildcards(name):
+def _gen_wildcards(name: str) -> List[str]:
     chunked = name.split(".")
     res = [name]
     for elem in reversed(chunked):
@@ -15,8 +18,8 @@ def _gen_wildcards(name):
     return res
 
 
-def get_config(app):
-    res = dict()
+def get_config(app: Celery) -> Dict[str, Any]:
+    res: Dict[str, Any] = dict()
     try:
         registered_tasks = app.control.inspect().registered_tasks().values()
         confs = app.control.inspect().conf()
@@ -44,16 +47,21 @@ def get_config(app):
     return res
 
 
-def get_transport_scheme(broker_url):
+def get_transport_scheme(broker_url: str) -> str:
     return urlparse(broker_url)[0]
 
 
 def generate_broker_use_ssl(
-    use_ssl, broker_scheme, ssl_verify, ssl_ca_certs, ssl_certfile, ssl_keyfile
-):
+    use_ssl: bool,
+    broker_scheme: str,
+    ssl_verify: str,
+    ssl_ca_certs,
+    ssl_certfile,
+    ssl_keyfile,
+) -> Optional[Dict[str, Any]]:
     scheme_map = {"redis": "ssl_", "amqp": ""}
 
-    verify_map = {
+    verify_map: Dict[str, ssl.VerifyMode] = {
         "CERT_NONE": ssl.CERT_NONE,
         "CERT_OPTIONAL": ssl.CERT_OPTIONAL,
         "CERT_REQUIRED": ssl.CERT_REQUIRED,


### PR DESCRIPTION
- typing improvements
- fix state type
- remove lingering line `local_received`
- use a simple shared Event dict type
- __main__/shutdown: add typing
- replace f-strings
- makefile: add combined `make tests`
