### PR TITLE
Fix blocking worker collector

### DIFF
--- a/celery_exporter/core.py
+++ b/celery_exporter/core.py
@@ -9,7 +9,7 @@ from .monitor import (
     EnableEventsThread,
     QueueLengthCollector,
     TaskThread,
-    WorkerCollector,
+    WorkerCollectorThread,
     setup_metrics,
 )
 
@@ -60,8 +60,13 @@ class CeleryExporter:
             logger.debug("Registering QueueLengthCollector")
             REGISTRY.register(QueueLengthCollector(app=self._app, queue_list=self._queues))
 
-        logger.debug("Registering WorkerCollector")
-        REGISTRY.register(WorkerCollector(app=self._app, namespace=self._namespace))
+        w = WorkerCollectorThread(
+            app=self._app,
+            namespace=self._namespace,
+        )
+        w.daemon = True
+        logger.debug("Starting WorkerCollectorThread")
+        w.start()
 
         if self._enable_events:
             e = EnableEventsThread(app=self._app)

--- a/celery_exporter/metrics.py
+++ b/celery_exporter/metrics.py
@@ -47,3 +47,9 @@ TASKS = prometheus_client.Counter(
     "Number of task events.",
     ["namespace", "name", "state", "queue"],
 )
+
+WORKERS = prometheus_client.Gauge(
+    "celery_workers",
+    "Number of alive workers.",
+    ["namespace"],
+)

--- a/celery_exporter/monitor.py
+++ b/celery_exporter/monitor.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Set
 import amqp
 import celery
 import celery.states
+from celery.app.control import Control
 from celery.events.receiver import EventReceiver
 from celery.utils.objects import FallbackContext
 from loguru import logger
@@ -12,7 +13,7 @@ from prometheus_client.core import GaugeMetricFamily
 from prometheus_client.registry import Collector
 
 from .celery_state import CeleryState, Event
-from .metrics import LATENCY, TASKS, TASKS_RUNTIME
+from .metrics import LATENCY, TASKS, TASKS_RUNTIME, WORKERS
 from .utils import get_config
 
 
@@ -66,25 +67,35 @@ class TaskThread(threading.Thread):
                 time.sleep(5)
 
 
-class WorkerCollector(Collector):
+class WorkerCollectorThread(threading.Thread):
+    """
+    WorkerCollectorThread broadcasts a ping to all workers and updates the
+    `celery_workers` metric accordingly. This is done in a separate thread because
+    the ping operation is blocking until celery_ping_timeout_seconds is reached.
+    """
+
     celery_ping_timeout_seconds = 5
 
-    def __init__(self, app: celery.Celery, namespace: str):
+    def __init__(self, app: celery.Celery, namespace: str, *args, **kwargs):
         self._app = app
         self._namespace = namespace
+        super(WorkerCollectorThread, self).__init__(*args, **kwargs)
 
-    def collect(self):
-        try:
-            workers = GaugeMetricFamily(
-                "celery_workers", "Number of alive workers", labels=["namespace"]
-            )
-            workers.add_metric(
-                [self._namespace],
-                len(self._app.control.ping(timeout=self.celery_ping_timeout_seconds)),
-            )
-            yield workers
-        except Exception:  # pragma: no cover
-            logger.exception("Error while pinging workers")
+    def run(self):  # pragma: no cover
+        while True:
+            try:
+                logger.trace("Pinging workers")
+                self._ping()
+            except Exception:
+                logger.error("Error while pinging workers")
+                time.sleep(5)
+
+    def _ping(self):
+        control: Control = self._app.control
+        workers_ping = control.ping(timeout=self.celery_ping_timeout_seconds)
+        # avoid edge case where workers_ping could be None
+        if workers_ping is not None:
+            WORKERS.labels(namespace=self._namespace).set(len(workers_ping))
 
 
 class EnableEventsThread(threading.Thread):
@@ -156,3 +167,4 @@ def setup_metrics(app: celery.Celery, namespace: str):
             LATENCY.labels(namespace=namespace, name=task, queue=queue)
             for state in celery.states.ALL_STATES:
                 TASKS.labels(namespace=namespace, name=task, state=state, queue=queue)
+        WORKERS.labels(namespace=namespace)

--- a/celery_exporter/monitor.py
+++ b/celery_exporter/monitor.py
@@ -90,6 +90,8 @@ class WorkerCollectorThread(threading.Thread):
             except Exception as e:
                 logger.error("Error while pinging workers")
                 logger.exception(e)
+                # reset the metric so we don't have stale metrics shown forever
+                WORKERS.labels(namespace=self._namespace).set(0)
                 time.sleep(5)
 
     def _ping(self):

--- a/celery_exporter/monitor.py
+++ b/celery_exporter/monitor.py
@@ -97,8 +97,11 @@ class WorkerCollectorThread(threading.Thread):
     def _ping(self):
         control: Control = self._app.control
         workers_ping = control.ping(timeout=self.celery_ping_timeout_seconds)
-        # avoid edge case where workers_ping could be None
-        if workers_ping is not None:
+
+        if workers_ping is None:
+            # edge case where workers_ping can be None: reset metric to avoid staleness
+            WORKERS.labels(namespace=self._namespace).set(0)
+        else:
             WORKERS.labels(namespace=self._namespace).set(len(workers_ping))
 
 

--- a/celery_exporter/monitor.py
+++ b/celery_exporter/monitor.py
@@ -61,8 +61,9 @@ class TaskThread(threading.Thread):
                     setup_metrics(self._app, self._namespace)
                     logger.info("Start capturing events...")
                     recv.capture(limit=None, timeout=None, wakeup=True)
-            except Exception:
-                logger.exception("Connection failed")
+            except Exception as e:
+                logger.error("Connection failed")
+                logger.exception(e)
                 setup_metrics(self._app, self._namespace)
                 time.sleep(5)
 
@@ -86,8 +87,9 @@ class WorkerCollectorThread(threading.Thread):
             try:
                 logger.trace("Pinging workers")
                 self._ping()
-            except Exception:
+            except Exception as e:
                 logger.error("Error while pinging workers")
+                logger.exception(e)
                 time.sleep(5)
 
     def _ping(self):
@@ -109,8 +111,9 @@ class EnableEventsThread(threading.Thread):
         while True:
             try:
                 self.enable_events()
-            except Exception:
-                logger.exception("Error while trying to enable events")
+            except Exception as e:
+                logger.error("Error while trying to enable events")
+                logger.exception(e)
             time.sleep(self.periodicity_seconds)
 
     def enable_events(self):

--- a/celery_exporter/utils.py
+++ b/celery_exporter/utils.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 from celery import Celery
+from loguru import logger
 
 CELERY_DEFAULT_QUEUE = "celery"
 CELERY_MISSING_DATA = "undefined"
@@ -23,7 +24,9 @@ def get_config(app: Celery) -> Dict[str, Any]:
     try:
         registered_tasks = app.control.inspect().registered_tasks().values()
         confs = app.control.inspect().conf()
-    except Exception:  # pragma: no cover
+    except Exception as e:  # pragma: no cover
+        logger.warning("Failed to get celery configuration, falling back to empty default")
+        logger.exception(e)
         return res
 
     default_queues = []

--- a/test/test_func.py
+++ b/test/test_func.py
@@ -9,7 +9,7 @@ from celery_exporter.core import CeleryExporter
 prom_http_server_mock = MagicMock(return_value=None)
 setup_metrics_mock = MagicMock(return_value=None)
 task_thread_mock = MagicMock(spec=celery_exporter.monitor.TaskThread)
-worker_collector_mock = MagicMock(spec=celery_exporter.monitor.WorkerCollector)
+worker_collector_thread_mock = MagicMock(spec=celery_exporter.monitor.WorkerCollectorThread)
 event_thread_mock = MagicMock(spec=celery_exporter.monitor.EnableEventsThread)
 
 
@@ -17,7 +17,7 @@ event_thread_mock = MagicMock(spec=celery_exporter.monitor.EnableEventsThread)
 @patch("celery_exporter.core.prometheus_client.start_http_server", prom_http_server_mock)
 @patch("celery_exporter.core.setup_metrics", setup_metrics_mock)
 @patch("celery_exporter.core.TaskThread", task_thread_mock)
-@patch("celery_exporter.core.WorkerCollector", worker_collector_mock)
+@patch("celery_exporter.core.WorkerCollectorThread", worker_collector_thread_mock)
 @patch("celery_exporter.core.EnableEventsThread", event_thread_mock)
 class TestCeleryExporter(BaseTest):
     def setUp(self):
@@ -47,7 +47,9 @@ class TestCeleryExporter(BaseTest):
 
     def test_worker_thread(self):
         self.cel_exp.start()
-        worker_collector_mock.assert_called_with(self.cel_exp._app, TestCeleryExporter.namespace)
+        worker_collector_thread_mock.assert_called_with(
+            self.cel_exp._app, TestCeleryExporter.namespace
+        )
 
     def test_event_thread(self):
         self.cel_exp.start()

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -80,6 +80,20 @@ class TestMockedCelery(BaseTest):
                 == 2
             )
 
+            mock_ping.return_value = None  # edge case
+            w._ping()
+            assert (
+                REGISTRY.get_sample_value("celery_workers", labels=dict(namespace=self.namespace))
+                == 0
+            )
+
+            mock_ping.return_value = [{"celery@node1": {"ok": "pong"}}]  # 1 worker
+            w._ping()
+            assert (
+                REGISTRY.get_sample_value("celery_workers", labels=dict(namespace=self.namespace))
+                == 1
+            )
+
             mock_ping.return_value = []
             w._ping()
             assert (


### PR DESCRIPTION
- Use threaded `WorkerCollectorThread` to avoid the worker ping blocking the main thread
  - Root cause is that the celery control's `ping` command broadcasts and waits for the entire timeout period for pings to return (5 seconds in our case) before unblocking the thread.
- more Exception logging
- update `WorkerCollectorThread` test cases with realistic data